### PR TITLE
fix: no longer use nodenv in gh action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-    - name: nodenv/setup-nodenv
-      uses: nodenv/actions-setup-nodenv@v2.0.4
     - uses: actions/checkout@v1
+    - name: Use Node.js 14.15.1
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.15.1
     - name: install eslint
       run: npm install 
     - name: lint


### PR DESCRIPTION
nodenv action is brokenuntil this issue is resolved: https://github.com/nodenv/actions/issues/13